### PR TITLE
Fix incorrect decimal separator with non-english system locale.

### DIFF
--- a/BoneEditor/Bone.cs
+++ b/BoneEditor/Bone.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.ComponentModel;
+using System.Globalization;
 using System.Runtime.CompilerServices;
 using BoneEditor.Annotations;
 
@@ -99,7 +100,10 @@ namespace BoneEditor
 
         public override string ToString()
         {
-            return $"{Id},{Code},{Enabled},{X:0.##},{Y:0.##},{Z:0.##},{B:0.##}";
-        }
+            return String.Format(CultureInfo.GetCultureInfo("en-US"), "{0},{1},{2},{3:0.##},{4:0.##},{5:0.##},{6:0.##}", new object[]
+            {
+               Id, Code, Enabled, X, Y, Z, B
+            });
+      }
     }
 }

--- a/BoneEditor/MainWindow.xaml.cs
+++ b/BoneEditor/MainWindow.xaml.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Text;
@@ -111,6 +112,7 @@ namespace BoneEditor
         {
             FileLoaded = false;
             Bones.Clear();
+            var EnUsCultureInfo = CultureInfo.GetCultureInfo("en-US");
             foreach (var line in File.ReadLines(s))
             {
                 var parts = line.Split(',');
@@ -118,10 +120,10 @@ namespace BoneEditor
                 {
                     Id = int.Parse(parts[0]),
                     Code = parts[1],
-                    X = double.Parse(parts[3]),
-                    Y = double.Parse(parts[4]),
-                    Z = double.Parse(parts[5]),
-                    B = double.Parse(parts[6])
+                    X = double.Parse(parts[3], EnUsCultureInfo),
+                    Y = double.Parse(parts[4], EnUsCultureInfo),
+                    Z = double.Parse(parts[5], EnUsCultureInfo),
+                    B = double.Parse(parts[6], EnUsCultureInfo)
                 };
                 Bones.Add(b);
             }


### PR DESCRIPTION
Hello. The decimal separator in Russian is comma, but not the dot, which makes it impossible to use this tool on Russian Windows installation (I suppose there are more languages with non-dot decimal separator)
This PR fixes that.